### PR TITLE
Added explicit format for datetime2 series

### DIFF
--- a/src/MarketData.jl
+++ b/src/MarketData.jl
@@ -30,7 +30,7 @@ export AAPL,
   const ohlc      = AAPL["Open", "High", "Low", "Close"][Date(2000,1,1):Date(2001,12,31)] 
   const ohlcv     = AAPL["Open", "High", "Low", "Close", "Volume"][Date(2000,1,1):Date(2001,12,31)] 
   const datetime1 = readtimearray(Pkg.dir("MarketData/data/datetime1.csv"))
-  const datetime2 = readtimearray(Pkg.dir("MarketData/data/datetime2.csv"))
+  const datetime2 = readtimearray(Pkg.dir("MarketData/data/datetime2.csv"), format="yyyy-mm-dd HH:MM:SS")
   const mdata     = TimeArray(cl.timestamp, cl.values, cl.colnames, "Apple") # data with meta field occupied
 
 end


### PR DESCRIPTION
Automagic parsing for `yyyy-mm-dd HH:MM:SS` was removed in https://github.com/JuliaLang/julia/pull/12799, so this adds an explicit format string for processing the datetime2 data series and gets tests passing again.