### PR TITLE
csv deprecation fix (#76)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MarketData"
 uuid = "945b72a4-3b13-509d-9b46-1525bb5c06de"
 authors = ["JuliaQuant <https://github.com/JuliaQuant>"]
-version = "0.13.8"
+version = "0.13.9"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/src/downloads.jl
+++ b/src/downloads.jl
@@ -95,7 +95,7 @@ function yahoo(sym::AbstractString = "^GSPC", opt::YahooOpt = YahooOpt())
     url  = "https://$host.finance.yahoo.com/v7/finance/download/$sym"
     res  = HTTP.get(url, query = opt)
     @assert res.status == 200
-    csv = CSV.File(res.body, missingstrings = ["null"])
+    csv = CSV.File(res.body, missingstring = "null")
     sch = TimeSeries.Tables.schema(csv)
     TimeArray(csv, timestamp = first(sch.names)) |> cleanup_colname!
 end


### PR DESCRIPTION
For future references: `yahoo` function only uses single value `null` as missed values, so it is safe to change it to `missingstring`. If we ever need to update single value to a vector, we should continue to use `missingstring` but limit lowest supported version of `CSV` by `0.8` where deprecation was introduced.