### PR TITLE
updated missingstring for fred - DGS fixed

### DIFF
--- a/src/downloads.jl
+++ b/src/downloads.jl
@@ -134,7 +134,7 @@ function fred(data::String="CPIAUCNS")
     url = "http://research.stlouisfed.org/fred2/series/$data/downloaddata/$data.csv"
     res = HTTP.get(url)
     @assert res.status == 200
-    csv = CSV.File(res.body)
+    csv = CSV.File(res.body, missingstring=".")
     sch = TimeSeries.Tables.schema(csv)
     TimeArray(csv, timestamp = first(sch.names)) |> cleanup_colname!
 end

--- a/test/downloads.jl
+++ b/test/downloads.jl
@@ -5,6 +5,9 @@ using Test
     @testset "FRED" begin
         ta = fred()
         @test ta |> timestamp |> length > 100
+        ta = fred("DGS10")
+        @test ta |> timestamp |> length > 100
+        @test !(ta isa TimeArray{T} where T<:AbstractString)
     end
 
     @testset "Yahoo" begin


### PR DESCRIPTION
FRED returns data for all week days, and returns a period '.' for some dates (presumably bank holidays or non-market days for another reason).  This fix treats the missing data as a `missing` so allowing the CSV package to identify a numeric type.

Fixes #79 